### PR TITLE
user faster plug library, and persist subnet to scan

### DIFF
--- a/Dockerfile-arm64v8
+++ b/Dockerfile-arm64v8
@@ -7,7 +7,7 @@ WORKDIR /
 #COPY . . if you update the libs below build with --no-cache
 RUN go get -d github.com/gorilla/mux
 RUN go get -d github.com/me-box/lib-go-databox
-RUN go get -d github.com/sausheong/hs1xxplug
+RUN go get -d github.com/cgreenhalgh/hs1xxplug
 COPY . .
 RUN addgroup -S databox && adduser -S -g databox databox
 RUN GGO_ENABLED=0 GOOS=linux go build -a -tags netgo -installsuffix netgo -ldflags '-s -w' -o app /src/*.go

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -9,16 +9,16 @@ RUN go get -d github.com/cgreenhalgh/hs1xxplug
 RUN addgroup -S databox && adduser -S -g databox databox
 RUN GGO_ENABLED=0 GOOS=linux go build -a -tags netgo -installsuffix netgo -ldflags '-s -w' -o app /src/app.go
 
-FROM amd64/alpine:3.8
-COPY --from=gobuild /etc/passwd /etc/passwd
-RUN apk update && apk add libzmq
-USER databox
-WORKDIR /
-COPY --from=gobuild /app .
-COPY --from=gobuild /www/ /www/
-COPY --from=gobuild /tmpl/ /tmpl/
+#FROM amd64/alpine:3.8
+#COPY --from=gobuild /etc/passwd /etc/passwd
+#RUN apk update && apk add libzmq
+#USER databox
+#WORKDIR /
+#COPY --from=gobuild /app .
+#COPY --from=gobuild /www/ /www/
+#COPY --from=gobuild /tmpl/ /tmpl/
 LABEL databox.type="driver"
 EXPOSE 8080
 
-CMD ["./app"]
-#CMD ["sleep","2147483647"]
+#CMD ["./app"]
+CMD ["sleep","2147483647"]

--- a/src/app.go
+++ b/src/app.go
@@ -19,6 +19,11 @@ func getStatusEndpoint(w http.ResponseWriter, req *http.Request) {
 	w.Write([]byte("active\n"))
 }
 
+type UIInfo struct {
+	Plugs interface{}
+	Settings plugs.Settings
+}
+
 func displayUI(w http.ResponseWriter, req *http.Request) {
 	var templates *template.Template
 	templates, err := template.ParseFiles("tmpl/settings.tmpl")
@@ -28,7 +33,10 @@ func displayUI(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	s1 := templates.Lookup("settings.tmpl")
-	err = s1.Execute(w, plugs.GetPlugList())
+	err = s1.Execute(w, UIInfo{
+		Plugs: plugs.GetPlugList(),
+		Settings: plugs.GetSettings(),
+	})
 	if err != nil {
 		fmt.Println(err)
 		w.Write([]byte("error\n"))
@@ -70,6 +78,7 @@ func main() {
 	//start the plug handler it scans for new plugs and polls for data
 	go plugs.PlugHandler()
 
+	plugs.ReadSettings()
 	go plugs.ForceScan()
 
 	//

--- a/src/plugs/plugs.go
+++ b/src/plugs/plugs.go
@@ -27,9 +27,12 @@ var scan_sub_net = "192.168.0"
 //A list of known plugs
 var plugList = make(map[string]plug)
 
+var tsc = databox.NewDefaultCoreStoreClient(DATABOX_ZMQ_ENDPOINT)
+
 func PlugHandler() {
 
 	tsc := databox.NewDefaultCoreStoreClient(DATABOX_ZMQ_ENDPOINT)
+	ReadSettings()
 
 	for {
 		select {
@@ -217,6 +220,7 @@ func SetScanSubNet(subnet string) {
 	//TODO Validation
 
 	scan_sub_net = subnet
+	writeSettings()
 }
 
 // ForceScan will force a scan for new plugs
@@ -275,4 +279,49 @@ func isPlugInList(ip string) bool {
 
 func macToID(mac string) string {
 	return strings.Replace(mac, ":", "", -1)
+}
+
+const SETTINGS_DATASOURCEID = "TPLinkSettings"
+const SETTINGS_KEY = "settings"
+type Settings struct {
+	ScanSubNet string `json: "scan_sub_net"`
+}
+func GetSettings() Settings {
+	return Settings{
+		ScanSubNet: scan_sub_net,
+	}
+}
+
+func ReadSettings() {
+	var settings Settings
+	payload, err := tsc.KVJSON.Read(SETTINGS_DATASOURCEID, SETTINGS_KEY)
+	if err != nil {
+		fmt.Println("Error reading settings: "+err.Error())
+		return
+	}
+	err = json.Unmarshal(payload, &settings)
+	if err != nil {
+		fmt.Println("Error unmarshalling settings: "+err.Error())
+		return
+	}
+	if len( settings.ScanSubNet ) >0 {
+		scan_sub_net = settings.ScanSubNet
+		fmt.Println("Restore scan_sub_net to ", scan_sub_net)
+	}
+}
+
+func writeSettings() {
+	settings := Settings{
+		ScanSubNet:  scan_sub_net,
+	}
+	jsonData, err :=  json.Marshal(settings)
+	if err != nil {
+		fmt.Println("Error marshalling settings: "+err.Error())
+		return
+	}	
+	err = tsc.KVJSON.Write(SETTINGS_DATASOURCEID, SETTINGS_KEY, []byte(jsonData))
+	if err != nil {
+		fmt.Println("Error writing settings: "+err.Error())
+	}
+	fmt.Println("Wrote settings")
 }

--- a/tmpl/settings.tmpl
+++ b/tmpl/settings.tmpl
@@ -17,7 +17,7 @@
         <div class="plugs">
         <h1>Available Plugs</h1>
         <hr>
-        {{ if .}} {{range .}}
+        {{ if .Plugs}} {{range .Plugs}}
         <div class="plug">
             <span class="name">{{.Name}}</span> 
             <span class="mac">{{.Mac}}</span> 
@@ -34,7 +34,7 @@
         <div class="form">
             <form id="add">
             <label for="ip">Enter sub net to scan (format xxx.xxx.xxx)</label>
-            <input type="text" name="plugSubNet" id="ip" value="192.168.0"><br><br>
+            <input type="text" name="plugSubNet" id="ip" value="{{if .Settings}}{{.Settings.ScanSubNet}}{{end}}"><br><br>
             <input id="addPlug" type="button" value="Scan">
             </form>
         </div>


### PR DESCRIPTION
With some (newer?) smart plugs the actuate operation blocks for ~20 seconds.
I've modified the plug control library so it's faster with these plugs.
Also persisted the subnet to scan in the store so that it works across container restarts, and included the plug name and ID in the description so that plugs are easier to identify in the UI.